### PR TITLE
feat: add check to correctly  scaffold examples for features in non i…

### DIFF
--- a/src/generators/app/index.js
+++ b/src/generators/app/index.js
@@ -47,8 +47,10 @@ export const AppMixin = subclass =>
       // This is needed as when ovverides is informed, it does not load questions and as
       // scaffoldOptions is created dinamically on there, they are not generated
       if (overrides && overrides.features && overrides.scaffoldFilesFor) {
-        scaffoldOptions = overrides.features.filter(feature => feature !== 'linting' && overrides.scaffoldFilesFor.includes(feature))
-      }      
+        scaffoldOptions = overrides.features.filter(
+          feature => feature !== 'linting' && overrides.scaffoldFilesFor.includes(feature),
+        );
+      }
 
       const questions = [
         {

--- a/src/generators/app/index.js
+++ b/src/generators/app/index.js
@@ -45,7 +45,7 @@ export const AppMixin = subclass =>
       let scaffoldOptions = [];
 
       // This is needed as when overrides is informed, it does not load questions and as
-      // scaffoldOptions is created dinamically on there, they are not generated
+      // scaffoldOptions is created dynamically on there, they are not generated
       if (overrides && overrides.features && overrides.scaffoldFilesFor) {
         scaffoldOptions = overrides.features.filter(
           feature => feature !== 'linting' && overrides.scaffoldFilesFor.includes(feature),

--- a/src/generators/app/index.js
+++ b/src/generators/app/index.js
@@ -44,7 +44,7 @@ export const AppMixin = subclass =>
 
       let scaffoldOptions = [];
 
-      // This is needed as when ovverides is informed, it does not load questions and as
+      // This is needed as when overrides is informed, it does not load questions and as
       // scaffoldOptions is created dinamically on there, they are not generated
       if (overrides && overrides.features && overrides.scaffoldFilesFor) {
         scaffoldOptions = overrides.features.filter(

--- a/src/generators/app/index.js
+++ b/src/generators/app/index.js
@@ -41,7 +41,15 @@ export const AppMixin = subclass =>
 
     async execute() {
       console.log(header);
-      const scaffoldOptions = [];
+
+      let scaffoldOptions = [];
+
+      // This is needed as when ovverides is informed, it does not load questions and as
+      // scaffoldOptions is created dinamically on there, they are not generated
+      if (overrides && overrides.features && overrides.scaffoldFilesFor) {
+        scaffoldOptions = overrides.features.filter(feature => feature !== 'linting' && overrides.scaffoldFilesFor.includes(feature))
+      }      
+
       const questions = [
         {
           type: 'select',

--- a/test/snapshots/fully-loaded-app/stories/scaffold-app.stories.js
+++ b/test/snapshots/fully-loaded-app/stories/scaffold-app.stories.js
@@ -1,0 +1,11 @@
+import { html } from 'lit-html';
+import '../src/scaffold-app.js';
+
+export default {
+  title: 'scaffold-app',
+};
+
+export const App = () =>
+  html`
+    <scaffold-app></scaffold-app>
+  `;

--- a/test/snapshots/fully-loaded-app/test/scaffold-app.test.js
+++ b/test/snapshots/fully-loaded-app/test/scaffold-app.test.js
@@ -1,0 +1,22 @@
+import { html, fixture, expect } from '@open-wc/testing';
+
+import '../src/scaffold-app.js';
+
+describe('ScaffoldApp', () => {
+  let element;
+  beforeEach(async () => {
+    element = await fixture(html`
+      <scaffold-app></scaffold-app>
+    `);
+  });
+
+  it('renders a h1', () => {
+    const h1 = element.shadowRoot.querySelector('h1');
+    expect(h1).to.exist;
+    expect(h1.textContent).to.equal('My app');
+  });
+
+  it('passes the a11y audit', async () => {
+    await expect(element).shadowDom.to.be.accessible();
+  });
+});


### PR DESCRIPTION
…nteractive mode

## What I did

1. Added a check to verify if `overrides.features` and `overrides.scaffoldFilesFor` where informed (that corresponds to these options in non-interactive mode). If so, adds the features to `scaffoldOptions` so them can be generated later.

This was needed as `scaffoldOptions` is dynamically generated during the questions answers but in non-interactive mode, the questions are not loaded and therefore `scaffoldOptions` was not created. In normal mode it still works as no `overrides` is informed.

Fixes https://github.com/open-wc/open-wc/issues/1864
