### PR TITLE
Remove reference to undeclared variable in styles

### DIFF
--- a/src/generators/app-lit-element/templates/_MyApp.js
+++ b/src/generators/app-lit-element/templates/_MyApp.js
@@ -21,7 +21,6 @@ export class <%= className %> extends LitElement {
         max-width: 960px;
         margin: 0 auto;
         text-align: center;
-        background-color: var(--<%= tagName %>-background-color);
       }
 
       main {


### PR DESCRIPTION
## What I did

1. Removed reference to undeclared variable from component styles. This will continue using the internal stylesheet's `background-color`, as defined in `index.html`, `#ECECED`.

