### PR TITLE
Declare css var referenced in template

### DIFF
--- a/src/generators/app-lit-element/templates/MyApp.js
+++ b/src/generators/app-lit-element/templates/MyApp.js
@@ -11,6 +11,7 @@ export class <%= className %> extends LitElement {
   static get styles() {
     return css`
       :host {
+        --<%= tagName %>-background-color: #ededed;
         min-height: 100vh;
         display: flex;
         flex-direction: column;


### PR DESCRIPTION
## What I did

1. add a declaration for the variable referenced in the :host style's background-color rule.

see [the original pr](https://github.com/open-wc/create/pull/13) for reference.