### PR TITLE
Declare css var referenced in template

### DIFF
--- a/src/generators/app-lit-element-ts/templates/MyApp.ts
+++ b/src/generators/app-lit-element-ts/templates/MyApp.ts
@@ -6,6 +6,7 @@ export class <%= className %> extends LitElement {
 
   static styles = css`
     :host {
+      --<%= tagName %>-background-color: #ededed;
       min-height: 100vh;
       display: flex;
       flex-direction: column;


### PR DESCRIPTION

## What I did

1. Add a declaration for a variable referenced in the :host style's background-color rule. Essentially the same as [another PR](https://github.com/open-wc/create/pull/19) but for the ts starter.