### PR TITLE
feat(ejs include): add config filename to allow caching and include 

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -95,7 +95,7 @@ export function resetVirtualFiles() {
  */
 export function processTemplate(_fileContent, data = {}) {
   let fileContent = _fileContent;
-  fileContent = render(fileContent, data, { debug: false });
+  fileContent = render(fileContent, data, { debug: false, filename: 'template' });
   return fileContent;
 }
 


### PR DESCRIPTION
I did add a filename in option.
Based on [ejs doc](https://ejs.co/#docs), and code inspected from ejs dependancy, it is mandatory to allow following functionalities:
- caching
- include
