### PR TITLE
feat: allow passing custom EJS options

### DIFF
--- a/src/Generator.js
+++ b/src/Generator.js
@@ -66,16 +66,16 @@ class Generator {
     return path.join(this.options.destinationPath, destination);
   }
 
-  copyTemplate(from, to) {
-    copyTemplate(from, to, this.templateData);
+  copyTemplate(from, to, ejsOptions = {}) {
+    copyTemplate(from, to, this.templateData, ejsOptions);
   }
 
-  copyTemplateJsonInto(from, to, options = { mode: 'merge' }) {
-    copyTemplateJsonInto(from, to, this.templateData, options);
+  copyTemplateJsonInto(from, to, options = { mode: 'merge' }, ejsOptions = {}) {
+    copyTemplateJsonInto(from, to, this.templateData, options, ejsOptions);
   }
 
-  async copyTemplates(from, to = this.destinationPath()) {
-    return copyTemplates(from, to, this.templateData);
+  async copyTemplates(from, to = this.destinationPath(), ejsOptions = {}) {
+    return copyTemplates(from, to, this.templateData, ejsOptions);
   }
 
   async end() {

--- a/src/core.js
+++ b/src/core.js
@@ -89,13 +89,16 @@ export function resetVirtualFiles() {
  * processTemplate('prefix <%= name %> suffix', { name: 'foo' })
  * // prefix foo suffix
  *
+ * It's also possible to pass custom options to EJS render like changing the delimiter of tags.
+ *
  * @param {string} _fileContent Template as a string
  * @param {object} data Object of all the variables to repalce
+ * @param {ejs.Options} ejsOptions
  * @returns {string} Template with all replacements
  */
-export function processTemplate(_fileContent, data = {}) {
+export function processTemplate(_fileContent, data = {}, ejsOptions = {}) {
   let fileContent = _fileContent;
-  fileContent = render(fileContent, data, { debug: false, filename: 'template' });
+  fileContent = render(fileContent, data, { debug: false, filename: 'template', ...ejsOptions });
   return fileContent;
 }
 
@@ -342,11 +345,12 @@ export function optionsToCommand(options, generatorName = '@open-wc') {
  * @param {string} fromPath
  * @param {string} toPath
  * @param {object} data
+ * @param {ejs.Options} ejsOptions
  */
-export function copyTemplate(fromPath, toPath, data) {
+export function copyTemplate(fromPath, toPath, data, ejsOptions = {}) {
   const fileContent = readFileFromPath(fromPath);
   if (fileContent) {
-    const processed = processTemplate(fileContent, data);
+    const processed = processTemplate(fileContent, data, ejsOptions);
     writeFileToPath(toPath, processed);
   }
 }
@@ -356,8 +360,9 @@ export function copyTemplate(fromPath, toPath, data) {
  * @param {string} fromGlob
  * @param {string} [toDir] Directory to copy into
  * @param {object} data Replace parameters in files
+ * @param {ejs.Options} ejsOptions
  */
-export function copyTemplates(fromGlob, toDir = process.cwd(), data = {}) {
+export function copyTemplates(fromGlob, toDir = process.cwd(), data = {}, ejsOptions = {}) {
   return new Promise(resolve => {
     glob(fromGlob, { dot: true }, (er, files) => {
       const copiedFiles = [];
@@ -365,7 +370,7 @@ export function copyTemplates(fromGlob, toDir = process.cwd(), data = {}) {
         if (!fs.lstatSync(filePath).isDirectory()) {
           const fileContent = readFileFromPath(filePath);
           if (fileContent !== false) {
-            const processed = processTemplate(fileContent, data);
+            const processed = processTemplate(fileContent, data, ejsOptions);
 
             // find path write to (force / also on windows)
             const replace = path.join(fromGlob.replace(/\*/g, '')).replace(/\\(?! )/g, '/');
@@ -386,18 +391,20 @@ export function copyTemplates(fromGlob, toDir = process.cwd(), data = {}) {
  * @param {string} fromPath
  * @param {string} toPath
  * @param {object} data
+ * @param {ejs.Options} ejsOptions
  */
 export function copyTemplateJsonInto(
   fromPath,
   toPath,
   data = {},
   { mode = 'merge' } = { mode: 'merge' },
+  ejsOptions = {},
 ) {
   const content = readFileFromPath(fromPath);
   if (content === false) {
     return;
   }
-  const processed = processTemplate(content, data);
+  const processed = processTemplate(content, data, ejsOptions);
   const mergeMeObj = JSON.parse(processed);
 
   const overwriteMerge = (destinationArray, sourceArray) => sourceArray;

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -40,6 +40,12 @@ describe('processTemplate', () => {
       expect(e).to.be.an.instanceof(ReferenceError);
     }
   });
+
+  it('allows passing custom EJS options like changing the delimiter', async () => {
+    expect(
+      processTemplate('prefix <?= name ?> suffix', { name: 'foo' }, { delimiter: '?' }),
+    ).to.equal('prefix foo suffix');
+  });
 });
 
 describe('writeFileToPath', () => {

--- a/test/snapshots/fully-loaded-app/package.json
+++ b/test/snapshots/fully-loaded-app/package.json
@@ -1,19 +1,19 @@
 {
   "devDependencies": {
-    "eslint": "^7.18.0",
+    "eslint": "^7.24.0",
     "@open-wc/eslint-config": "^4.2.0",
     "prettier": "^2.2.1",
     "eslint-config-prettier": "^7.2.0",
     "husky": "^4.3.8",
-    "lint-staged": "^10.5.3",
-    "@web/test-runner": "^0.12.7",
+    "lint-staged": "^10.5.4",
+    "@web/test-runner": "^0.12.20",
     "@open-wc/testing": "^2.5.32",
-    "@web/dev-server-storybook": "^0.3.3",
+    "@web/dev-server-storybook": "^0.3.5",
     "@open-wc/building-rollup": "^1.9.4",
     "deepmerge": "^4.2.2",
     "rimraf": "^3.0.2",
-    "rollup": "^2.38.0",
-    "@web/dev-server": "^0.1.5"
+    "rollup": "^2.45.2",
+    "@web/dev-server": "^0.1.12"
   },
   "scripts": {
     "lint": "eslint --ext .js,.html . --ignore-path .gitignore && prettier \"**/*.js\" --check --ignore-path .gitignore",


### PR DESCRIPTION
## What I did

1. Allow passing custom EJS options to EJS.render() in processTemplate. 

Main use case for me is that I use @open-wc/create utilities directly in a node project for basic scaffolding tasks. Simultaneously, I am extending @open-wc/create fully for my generator. I end up with a file like:

`src/web-frontend/templates/template/index.html`:

```html
<head>
  <style>
    body {
      margin: 0;
      padding: 0;
    }
  </style>
</head>
<body>
  <h2>Hello, <%= participantName %></h2>
  <script src="./index.js"></script>
</body>
```
But here the tag is not meant to be picked up by the open-wc generator, it is to be picked up my own node project (which uses @open-wc/create --> processTemplate too). 

So basically, it is **templates within templates** 🙈 and EJS doesn't distinguish of course, it cannot know.

There's a pretty elegant solution around this, and this is to use different delimiters for different layers. I can use `<?= ?>` for example by changing the delimiter to `?` and that will "just work" and solve my problem. So I added the feature to pass custom EJS options :), because if I change the tags in my node project it would be a breaking change for my users.
