### PR TITLE
fix: dont analyze dist

### DIFF
--- a/src/generators/building-rollup-ts/templates/package.json
+++ b/src/generators/building-rollup-ts/templates/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "rimraf dist && tsc && rollup -c rollup.config.js && <%= scriptRunCommand %> analyze",
+    "build": "rimraf dist && tsc && rollup -c rollup.config.js && <%= scriptRunCommand %> analyze --exclude dist",
     "start:build": "web-dev-server --root-dir dist --app-index index.html --open"
   },
   "devDependencies": {

--- a/src/generators/building-rollup/templates/package.json
+++ b/src/generators/building-rollup/templates/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "rimraf dist && rollup -c rollup.config.js && <%= scriptRunCommand %> analyze",
+    "build": "rimraf dist && rollup -c rollup.config.js && <%= scriptRunCommand %> analyze --exclude dist",
     "start:build": "web-dev-server --root-dir dist --app-index index.html --open"
   },
   "devDependencies": {

--- a/src/generators/demoing-storybook-ts/templates/package.json
+++ b/src/generators/demoing-storybook-ts/templates/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "storybook": "tsc && <%= scriptRunCommand %> analyze && concurrently -k -r \"tsc --watch --preserveWatchOutput\" \"wds -c .storybook/server.mjs\"",
-    "storybook:build": "tsc && <%= scriptRunCommand %> analyze && build-storybook"
+    "storybook": "tsc && <%= scriptRunCommand %> analyze --exclude dist && concurrently -k -r \"tsc --watch --preserveWatchOutput\" \"wds -c .storybook/server.mjs\"",
+    "storybook:build": "tsc && <%= scriptRunCommand %> analyze --exclude dist && build-storybook"
   },
   "devDependencies": {
     "@web/dev-server-storybook": "next"

--- a/src/generators/demoing-storybook/templates/package.json
+++ b/src/generators/demoing-storybook/templates/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "storybook": "<%= scriptRunCommand %> analyze && web-dev-server -c .storybook/server.mjs",
-    "storybook:build": "<%= scriptRunCommand %> analyze && build-storybook"
+    "storybook": "<%= scriptRunCommand %> analyze --exclude dist && web-dev-server -c .storybook/server.mjs",
+    "storybook:build": "<%= scriptRunCommand %> analyze --exclude dist && build-storybook"
   },
   "devDependencies": {
     "@web/dev-server-storybook": "next"

--- a/src/generators/wc-lit-element-ts/templates/package.json
+++ b/src/generators/wc-lit-element-ts/templates/package.json
@@ -7,8 +7,8 @@
   },
   "scripts": {
     "start": "tsc && concurrently -k -r \"tsc --watch --preserveWatchOutput\" \"wds\"",
-    "build": "tsc && <%= scriptRunCommand %> analyze",
-    "prepublish": "tsc && <%= scriptRunCommand %> analyze"
+    "build": "tsc && <%= scriptRunCommand %> analyze --exclude dist",
+    "prepublish": "tsc && <%= scriptRunCommand %> analyze --exclude dist"
   },
   "dependencies": {
     "lit": "^2.0.0-rc.3"


### PR DESCRIPTION
## What I did

1. Excludes `dist` from being analyzed by CEM/A, which caused freshly scaffolded projects to fail on the `build` command. 