### PR TITLE
Filter out lit 2.x logs

### DIFF
--- a/src/generators/app-lit-element/templates/static-testing/web-test-runner.config.mjs
+++ b/src/generators/app-lit-element/templates/static-testing/web-test-runner.config.mjs
@@ -1,6 +1,6 @@
 // import { playwrightLauncher } from '@web/test-runner-playwright';
 
-const filteredLogs = ['Running in dev mode', 'lit-html is in dev mode'];
+const filteredLogs = ['Running in dev mode', 'Lit is in dev mode'];
 
 export default /** @type {import("@web/test-runner").TestRunnerConfig} */ ({
   /** Test files to run */


### PR DESCRIPTION
## What I did

1. Changed string to filter out when running in dev mode

The new Lit version outputs `Lit is in dev mode`.
