### PR TITLE
webdev server hmr example: use lit v3

### DIFF
--- a/src/generators/wc-lit-element-ts/templates/static/web-dev-server.config.mjs
+++ b/src/generators/wc-lit-element-ts/templates/static/web-dev-server.config.mjs
@@ -20,7 +20,7 @@ export default /** @type {import('@web/dev-server').DevServerConfig} */ ({
 
   plugins: [
     /** Use Hot Module Replacement by uncommenting. Requires @open-wc/dev-server-hmr plugin */
-    // hmr && hmrPlugin({ exclude: ['**/*/node_modules/**/*'], presets: [presets.litElement] }),
+    // hmr && hmrPlugin({ exclude: ['**/*/node_modules/**/*'], presets: [presets.lit] }),
   ],
 
   // See documentation for all available options

--- a/src/generators/wc-lit-element/templates/static/web-dev-server.config.mjs
+++ b/src/generators/wc-lit-element/templates/static/web-dev-server.config.mjs
@@ -20,7 +20,7 @@ export default /** @type {import('@web/dev-server').DevServerConfig} */ ({
 
   plugins: [
     /** Use Hot Module Replacement by uncommenting. Requires @open-wc/dev-server-hmr plugin */
-    // hmr && hmrPlugin({ exclude: ['**/*/node_modules/**/*'], presets: [presets.litElement] }),
+    // hmr && hmrPlugin({ exclude: ['**/*/node_modules/**/*'], presets: [presets.lit] }),
   ],
 
   // See documentation for all available options


### PR DESCRIPTION
Update web-dev-server hmr example to use lit v3 preset ("lit") instead of lit v2 ("litElement")

Fixues https://github.com/open-wc/create/issues/81