### PR TITLE
feat: move to Storybook Builder from Storybook Pre-built

### DIFF
--- a/src/generators/app-lit-element-ts/templates/static-demoing/.storybook/main.js
+++ b/src/generators/app-lit-element-ts/templates/static-demoing/.storybook/main.js
@@ -1,3 +1,8 @@
-module.exports = {
-  stories: ['../**/out-tsc/stories/*.stories.{js,md,mdx}'],
+const config = {
+  stories: ['../out-tsc/*.stories.{js,md,mdx}'],
+  framework: {
+    name: '@web/storybook-framework-web-components',
+  },
 };
+
+export default config;

--- a/src/generators/app-lit-element-ts/templates/static-demoing/.storybook/server.mjs
+++ b/src/generators/app-lit-element-ts/templates/static-demoing/.storybook/server.mjs
@@ -1,8 +1,0 @@
-import { storybookPlugin } from '@web/dev-server-storybook';
-import baseConfig from '../web-dev-server.config.mjs';
-
-export default /** @type {import('@web/dev-server').DevServerConfig} */ ({
-  ...baseConfig,
-  open: '/',
-  plugins: [storybookPlugin({ type: 'web-components' }), ...baseConfig.plugins],
-});

--- a/src/generators/app-lit-element-ts/templates/tsconfig.json
+++ b/src/generators/app-lit-element-ts/templates/tsconfig.json
@@ -14,7 +14,8 @@
     "sourceMap": true,
     "inlineSources": true,
     "rootDir": "./",
-    "incremental": true
+    "incremental": true,
+    "skipLibCheck": true
   },
   "include": ["**/*.ts"]
 }

--- a/src/generators/app-lit-element/templates/static-demoing/.storybook/main.js
+++ b/src/generators/app-lit-element/templates/static-demoing/.storybook/main.js
@@ -1,3 +1,8 @@
-module.exports = {
-  stories: ['../**/stories/*.stories.{js,md,mdx}'],
+const config = {
+  stories: ['../stories/*.stories.{js,md,mdx}'],
+  framework: {
+    name: '@web/storybook-framework-web-components',
+  },
 };
+
+export default config;

--- a/src/generators/app-lit-element/templates/static-demoing/.storybook/server.js
+++ b/src/generators/app-lit-element/templates/static-demoing/.storybook/server.js
@@ -1,8 +1,0 @@
-import { storybookPlugin } from '@web/dev-server-storybook';
-import baseConfig from '../web-dev-server.config.js';
-
-export default /** @type {import('@web/dev-server').DevServerConfig} */ ({
-  ...baseConfig,
-  open: '/',
-  plugins: [storybookPlugin({ type: 'web-components' }), ...baseConfig.plugins],
-});

--- a/src/generators/demoing-storybook-ts/templates/package.json
+++ b/src/generators/demoing-storybook-ts/templates/package.json
@@ -1,9 +1,15 @@
 {
   "scripts": {
-    "storybook": "tsc && <%= scriptRunCommand %> analyze -- --exclude dist && concurrently -k -r \"tsc --watch --preserveWatchOutput\" \"wds -c .storybook/server.mjs\"",
-    "storybook:build": "tsc && <%= scriptRunCommand %> analyze -- --exclude dist && build-storybook"
+    "storybook": "tsc && <%= scriptRunCommand %> analyze -- --exclude dist && concurrently -k -r \"tsc --watch --preserveWatchOutput\" \"storybook dev -p 8080\"",
+    "storybook:build": "tsc && <%= scriptRunCommand %> analyze -- --exclude dist && storybook build"
   },
   "devDependencies": {
-    "@web/dev-server-storybook": "^0.5.4"
+    "@storybook/addon-a11y": "^7.5.0",
+    "@storybook/addon-essentials": "^7.5.0",
+    "@storybook/addon-links": "^7.5.0",
+    "@storybook/web-components": "^7.5.0",
+    "@web/storybook-builder": "^0.1.16",
+    "@web/storybook-framework-web-components": "^0.1.2",
+    "storybook": "^7.5.0"
   }
 }

--- a/src/generators/demoing-storybook-ts/templates/static/.storybook/main.js
+++ b/src/generators/demoing-storybook-ts/templates/static/.storybook/main.js
@@ -1,3 +1,8 @@
-module.exports = {
-  stories: ['../dist/stories/**/*.stories.{js,md,mdx}'],
+const config = {
+  stories: ['../**/dist/stories/*.stories.{js,md,mdx}'],
+  framework: {
+    name: '@web/storybook-framework-web-components',
+  },
 };
+
+export default config;

--- a/src/generators/demoing-storybook-ts/templates/static/.storybook/server.mjs
+++ b/src/generators/demoing-storybook-ts/templates/static/.storybook/server.mjs
@@ -1,8 +1,0 @@
-import { storybookPlugin } from '@web/dev-server-storybook';
-import baseConfig from '../web-dev-server.config.mjs';
-
-export default /** @type {import('@web/dev-server').DevServerConfig} */ ({
-  ...baseConfig,
-  open: '/',
-  plugins: [storybookPlugin({ type: 'web-components' }), ...baseConfig.plugins],
-});

--- a/src/generators/demoing-storybook/templates/package.json
+++ b/src/generators/demoing-storybook/templates/package.json
@@ -1,9 +1,15 @@
 {
   "scripts": {
-    "storybook": "<%= scriptRunCommand %> analyze -- --exclude dist && web-dev-server -c .storybook/server.mjs",
-    "storybook:build": "<%= scriptRunCommand %> analyze -- --exclude dist && build-storybook"
+    "storybook": "<%= scriptRunCommand %> analyze -- --exclude dist && storybook dev -p 8080",
+    "storybook:build": "<%= scriptRunCommand %> analyze -- --exclude dist && storybook build"
   },
   "devDependencies": {
-    "@web/dev-server-storybook": "^0.5.4"
+    "@storybook/addon-a11y": "^7.5.0",
+    "@storybook/addon-essentials": "^7.5.0",
+    "@storybook/addon-links": "^7.5.0",
+    "@storybook/web-components": "^7.5.0",
+    "@web/storybook-builder": "^0.1.16",
+    "@web/storybook-framework-web-components": "^0.1.2",
+    "storybook": "^7.5.0"
   }
 }

--- a/src/generators/demoing-storybook/templates/static/.storybook/main.js
+++ b/src/generators/demoing-storybook/templates/static/.storybook/main.js
@@ -1,3 +1,8 @@
-module.exports = {
-  stories: ['../stories/**/*.stories.{js,md,mdx}'],
+const config = {
+  stories: ['../stories/*.stories.{js,md,mdx}'],
+  framework: {
+    name: '@web/storybook-framework-web-components',
+  },
 };
+
+export default config;

--- a/src/generators/demoing-storybook/templates/static/.storybook/server.mjs
+++ b/src/generators/demoing-storybook/templates/static/.storybook/server.mjs
@@ -1,8 +1,0 @@
-import { storybookPlugin } from '@web/dev-server-storybook';
-import baseConfig from '../web-dev-server.config.mjs';
-
-export default /** @type {import('@web/dev-server').DevServerConfig} */ ({
-  ...baseConfig,
-  open: '/',
-  plugins: [storybookPlugin({ type: 'web-components' }), ...baseConfig.plugins],
-});

--- a/src/generators/wc-lit-element-ts/templates/tsconfig.json
+++ b/src/generators/wc-lit-element-ts/templates/tsconfig.json
@@ -15,7 +15,8 @@
     "inlineSources": true,
     "rootDir": "./",
     "declaration": true,
-    "incremental": true
+    "incremental": true,
+    "skipLibCheck": true
   },
   "include": ["**/*.ts"]
 }

--- a/test/snapshots/fully-loaded-app/.storybook/server.js
+++ b/test/snapshots/fully-loaded-app/.storybook/server.js
@@ -1,8 +1,0 @@
-import { storybookPlugin } from '@web/dev-server-storybook';
-import baseConfig from '../web-dev-server.config.js';
-
-export default /** @type {import('@web/dev-server').DevServerConfig} */ ({
-  ...baseConfig,
-  open: '/',
-  plugins: [storybookPlugin({ type: 'web-components' }), ...baseConfig.plugins],
-});

--- a/test/snapshots/fully-loaded-app/.storybook/server.mjs
+++ b/test/snapshots/fully-loaded-app/.storybook/server.mjs
@@ -1,8 +1,0 @@
-import { storybookPlugin } from '@web/dev-server-storybook';
-import baseConfig from '../web-dev-server.config.mjs';
-
-export default /** @type {import('@web/dev-server').DevServerConfig} */ ({
-  ...baseConfig,
-  open: '/',
-  plugins: [storybookPlugin({ type: 'web-components' }), ...baseConfig.plugins],
-});


### PR DESCRIPTION
## What I did

1. Update Storybook options to leverage `@web/storybook-builder` and `@web/storybook-framework-web-components` as opposed to `@web/dev-server-storybook`
  - swap `package.json` commands
  - swap dependency listings
  - remove `server.mjs` files which are no longer needed
  - added `"skipLibCheck": true` to `tsconfig.json` to ignore TS issues in external dependencies

closes #91 
fixes #89
fixes #87
fixes #79
