### PR TITLE
ci: run CI against node 18, 20, and 22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-      - name: Setup Node.js 14.x
-        uses: actions/setup-node@master
+      - name: Setup Node.js 22.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 14.x
+          node-version: 22.x
           registry-url: 'https://registry.npmjs.org'
 
       - name: Get yarn cache directory path

--- a/.github/workflows/verify-node.yml
+++ b/.github/workflows/verify-node.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [18.x, 20.x, 22.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
@@ -30,8 +30,6 @@ jobs:
 
       - name: Lint
         run: yarn lint
-
-      - run: npm config set scripts-prepend-node-path true
 
       - name: Test
         run: yarn test

--- a/.github/workflows/verify-windows.yml
+++ b/.github/workflows/verify-windows.yml
@@ -16,12 +16,12 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Setup Node 14.x
-        uses: actions/setup-node@v2
+      - name: Setup Node 22.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 14.x
+          node-version: 22.x
           cache: 'yarn'
 
       - name: Install dependencies
@@ -29,8 +29,6 @@ jobs:
 
       - name: Build
         run: yarn build
-
-      - run: npm config set scripts-prepend-node-path true
 
       - name: Test
         run: yarn test


### PR DESCRIPTION
## What I did

1. Move CI tests to Node 18, 20, 22
2. Move windows test and release to Node 22
3. Use the latest GH Actions versions
