### PR TITLE
Use commit-and-tag-version directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:eslint": "eslint --ext .ts,.js,.mjs,.cjs .",
     "lint:prettier": "prettier \"**/*.{ts,js,mjs,cjs,md}\" --check --ignore-path .eslintignore",
     "format": "eslint --ext .ts,.js,.mjs,.cjs  --fix && prettier \"**/*.{ts,js,mjs,cjs,md}\" --check --ignore-path .eslintignore --write",
-    "release": "standard-version && git push --follow-tags origin master && npm publish",
+    "release": "commit-and-tag-version && git push --follow-tags origin master && npm publish",
     "start": "npm run build && node ./dist/create.js",
     "test": "npm run test:node",
     "test:node": "mocha --require @babel/register",


### PR DESCRIPTION
## What I did

1. Try with the migrated script not the deprecated one.
