### PR TITLE
remove: take "@babel/preset-env" out of the generators

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "devDependencies": {
     "@babel/cli": "^7.24.6",
     "@babel/core": "^7.24.6",
-    "@babel/preset-env": "^7.24.6",
     "@babel/register": "^7.24.6",
     "@custom-elements-manifest/analyzer": "^0.10.2",
     "@open-wc/eslint-config": "^12.0.3",

--- a/src/generators/building-rollup-ts/templates/package.json
+++ b/src/generators/building-rollup-ts/templates/package.json
@@ -4,7 +4,6 @@
     "start:build": "web-dev-server --root-dir dist --app-index index.html --open"
   },
   "devDependencies": {
-    "@babel/preset-env": "^7.24.6",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@web/rollup-plugin-html": "^2.3.0",

--- a/src/generators/building-rollup/templates/package.json
+++ b/src/generators/building-rollup/templates/package.json
@@ -4,7 +4,6 @@
     "start:build": "web-dev-server --root-dir dist --app-index index.html --open"
   },
   "devDependencies": {
-    "@babel/preset-env": "^7.24.6",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@web/rollup-plugin-html": "^2.3.0",

--- a/test/snapshots/fully-loaded-app/package.json
+++ b/test/snapshots/fully-loaded-app/package.json
@@ -22,7 +22,6 @@
     "lit": "^3.0.0"
   },
   "devDependencies": {
-    "@babel/preset-env": "^7.24.6",
     "@custom-elements-manifest/analyzer": "^0.10.2",
     "@open-wc/eslint-config": "^12.0.3",
     "@open-wc/testing": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -902,7 +902,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.24.6"
     "@babel/helper-plugin-utils" "^7.24.6"
 
-"@babel/preset-env@^7.11.0", "@babel/preset-env@^7.24.6":
+"@babel/preset-env@^7.11.0":
   version "7.24.6"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.24.6.tgz#a5a55bc70e5ff1ed7f872067e2a9d65ff917ad6f"
   integrity sha512-CrxEAvN7VxfjOG8JNF2Y/eMqMJbZPZ185amwGUBp8D9USK90xQmv7dLdFSa+VbD7fdIqcy/Mfv7WtzG8+/qxKg==


### PR DESCRIPTION
## What I did

1. Looks like it's not used anymore.
