### PR TITLE
Backslash-related fixes for Windows

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -277,9 +277,11 @@ export function filesToTree(allFiles, level = 0) {
  */
 export async function writeFilesToDisk() {
   const treeFiles = [];
-  const root = process.cwd().replace(/\\/g, "/");
+  const root = process.cwd().replace(/\\/g, '/');
 
-  virtualFiles.forEach(vFile => { vFile.path = vFile.path.replace(/\\/g, "/") } );
+  virtualFiles.forEach((vFile, i) => {
+    virtualFiles[i].path = vFile.path.replace(/\\/g, '/');
+  });
 
   virtualFiles.sort((a, b) => {
     const pathA = a.path.toLowerCase();

--- a/src/core.js
+++ b/src/core.js
@@ -369,7 +369,7 @@ export function copyTemplate(fromPath, toPath, data, ejsOptions = {}) {
  */
 export function copyTemplates(fromGlob, toDir = process.cwd(), data = {}, ejsOptions = {}) {
   return new Promise(resolve => {
-    glob(fromGlob, { dot: true }, (er, files) => {
+    glob(fromGlob, { dot: true, windowsPathsNoEscape: true }, (er, files) => {
       const copiedFiles = [];
       files.forEach(filePath => {
         if (!fs.lstatSync(filePath).isDirectory()) {

--- a/src/core.js
+++ b/src/core.js
@@ -277,7 +277,10 @@ export function filesToTree(allFiles, level = 0) {
  */
 export async function writeFilesToDisk() {
   const treeFiles = [];
-  const root = process.cwd();
+  const root = process.cwd().replace(/\\/g, "/");
+
+  virtualFiles.forEach(vFile => { vFile.path = vFile.path.replace(/\\/g, "/") } );
+
   virtualFiles.sort((a, b) => {
     const pathA = a.path.toLowerCase();
     const pathB = b.path.toLowerCase();


### PR DESCRIPTION
## What I did

1. Fixed open-wc/open-wc#2799, which was caused by a breaking change in glob v8;
2. Fixed tree view being displayed unnested on Windows, due to backslashes being used.
